### PR TITLE
Fix running tests from the command line (fixes #16)

### DIFF
--- a/src/leiningen/new/figwheel_main/deps.edn
+++ b/src/leiningen/new/figwheel_main/deps.edn
@@ -18,4 +18,4 @@
                  :extra-paths ["target" "test"]}
            :build {:main-opts ["-m" "figwheel.main" "-b" "dev" "-r"]}
            :min   {:main-opts ["-m" "figwheel.main" "-O" "advanced" "-bo" "dev"]}
-           :test  {:main-opts ["-m" "figwheel.main" "-co" "test.cljs.edn" "-m" {{test-runner-ns}}]}}}
+           :test  {:main-opts ["-m" "figwheel.main" "-co" "test.cljs.edn" "-m" "{{test-runner-ns}}"]}}}


### PR DESCRIPTION
`{{test-runner-ns}}` in `deps.edn` should be quoted.