### PR TITLE
bump rum version to enable use of awesome new features https://github…

### DIFF
--- a/src/leiningen/new/figwheel_main/deps.edn
+++ b/src/leiningen/new/figwheel_main/deps.edn
@@ -1,16 +1,16 @@
 {:deps {org.clojure/clojure {:mvn/version "1.9.0"}
         org.clojure/clojurescript {:mvn/version "1.10.520"}{{#om?}}
-        cljsjs/react {:mvn/version "16.4.1-0"}
-        cljsjs/react-dom {:mvn/version "16.4.1-0"}
+        cljsjs/react {:mvn/version "16.8.6-0"}
+        cljsjs/react-dom {:mvn/version "16.8.6-0"}
         cljsjs/create-react-class {:mvn/version "15.6.3-1"}
         sablono {:mvn/version "0.8.4"}
         org.omcljs/om {:mvn/version "1.0.0-beta4"}{{/om?}}{{#react?}}
-        cljsjs/react {:mvn/version "16.4.1-0"}
-        cljsjs/react-dom {:mvn/version "16.4.1-0"}
+        cljsjs/react {:mvn/version "16.8.6-0"}
+        cljsjs/react-dom {:mvn/version "16.8.6-0"}
         cljsjs/create-react-class {:mvn/version "15.6.3-1"}
         sablono {:mvn/version "0.8.4"}{{/react?}}{{#reagent?}}
         reagent {:mvn/version "0.8.1"}{{/reagent?}}{{#rum?}}
-        rum {:mvn/version "0.11.2"}{{/rum?}}}
+        rum {:mvn/version "0.11.5"}{{/rum?}}}
  :paths ["src" "resources"]
  :aliases {:fig {:extra-deps
                   {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}

--- a/src/leiningen/new/figwheel_main/project.clj
+++ b/src/leiningen/new/figwheel_main/project.clj
@@ -8,17 +8,17 @@
 
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.clojure/clojurescript "1.10.520"]{{#react?}}
-                 [cljsjs/react "16.4.1-0"]
-                 [cljsjs/react-dom "16.4.1-0"]
+                 [cljsjs/react "16.8.6-0"]
+                 [cljsjs/react-dom "16.8.6-0"]
                  [cljsjs/create-react-class "15.6.3-1"]
                  [sablono "0.8.4"]{{/react?}}{{#om?}}
-                 [cljsjs/react "16.4.1-0"]
-                 [cljsjs/react-dom "16.4.1-0"]
+                 [cljsjs/react "16.8.6-0"]
+                 [cljsjs/react-dom "16.8.6-0"]
                  [cljsjs/create-react-class "15.6.3-1"]
                  [sablono "0.8.4"]
                  [org.omcljs/om "1.0.0-beta4"]{{/om?}}{{#reagent?}}
                  [reagent "0.8.1"]{{/reagent?}}{{#rum?}}
-                 [rum "0.11.2"]{{/rum?}}]
+                 [rum "0.11.5"]{{/rum?}}]
 
   :source-paths ["src"]
 


### PR DESCRIPTION
Perhaps this is too soon, but quite a few great features are soon to land in Rum, and it would be great to see a version bump of Rum to support this. https://github.com/tonsky/rum/blob/gh-pages/CHANGELOG.md#0115-snapshot