### PR TITLE
bump rum to 0.11.5

### DIFF
--- a/src/leiningen/new/figwheel_main/deps.edn
+++ b/src/leiningen/new/figwheel_main/deps.edn
@@ -10,7 +10,7 @@
         cljsjs/create-react-class {:mvn/version "15.6.3-1"}
         sablono {:mvn/version "0.8.4"}{{/react?}}{{#reagent?}}
         reagent {:mvn/version "0.8.1"}{{/reagent?}}{{#rum?}}
-        rum {:mvn/version "0.11.2"}{{/rum?}}}
+        rum {:mvn/version "0.11.5"}{{/rum?}}}
  :paths ["src" "resources"]
  :aliases {:fig {:extra-deps
                   {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}

--- a/src/leiningen/new/figwheel_main/project.clj
+++ b/src/leiningen/new/figwheel_main/project.clj
@@ -18,7 +18,7 @@
                  [sablono "0.8.4"]
                  [org.omcljs/om "1.0.0-beta4"]{{/om?}}{{#reagent?}}
                  [reagent "0.8.1"]{{/reagent?}}{{#rum?}}
-                 [rum "0.11.2"]{{/rum?}}]
+                 [rum "0.11.5"]{{/rum?}}]
 
   :source-paths ["src"]
 


### PR DESCRIPTION
Rum just shipped a bunch of amazing features as part of the `0.11.5` release: https://gist.github.com/roman01la/b1888bedbafd328169e26c66dde5fd56. Would be great to update the Rum deps in the template!