### PR TITLE
Change Clojure CLI help in template output

### DIFF
--- a/src/leiningen/new/figwheel_main.clj
+++ b/src/leiningen/new/figwheel_main.clj
@@ -166,7 +166,7 @@
                                 "  -->  Start build with '%s'\n")
                            (:name data)
                            (if (:deps? data)
-                             "clojure -A:fig:build"
+                             "clojure -M:fig:build"
                              "lein fig:build")))
         (apply ->files data files)
         ;; ensure target directory


### PR DESCRIPTION
When you create a new project with the CLI, the "help" output suggests `clojure -A:fig:build` but this is deprecated in recent CLI versions and it should recommend `clojure -M:fig:build` instead.