### PR TITLE
Bump figwheel-main to newer version

### DIFF
--- a/src/leiningen/new/figwheel_main/deps.edn
+++ b/src/leiningen/new/figwheel_main/deps.edn
@@ -8,7 +8,7 @@
  :paths ["src" "resources"]
  :aliases {:fig {:extra-deps
                   {com.bhauman/rebel-readline-cljs {:mvn/version "0.1.4"}
-                   com.bhauman/figwheel-main {:mvn/version "0.2.11"}}
+                   com.bhauman/figwheel-main {:mvn/version "0.2.14"}}
                  :extra-paths ["target" "test"]}
            :build {:main-opts ["-m" "figwheel.main" "-b" "dev" "-r"]}
            :min   {:main-opts ["-m" "figwheel.main" "-O" "advanced" "-bo" "dev"]}


### PR DESCRIPTION
I'm using Macbook with M1 and had issue:

After running `clojure -M:fig:build`  [exception](https://gist.github.com/gs/0466a64b568dc2bb39dbba2cbfd9b0ab)  occurred.

After bumping the `com.bhauman/figwheel-main` to `0.2.14` this was gone.

Additionally, as suggested in this [thread](https://clojurians.slack.com/archives/C03S1L9DN/p1636156324403100?thread_ts=1636144775.400400&cid=C03S1L9DN) I installed java for ARM. Processor.