### PR TITLE
Update both main and template gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ hello_world
 hello-world
 \.\#*
 \#*
+.clj-kondo/.cache

--- a/src/leiningen/new/figwheel_main/gitignore
+++ b/src/leiningen/new/figwheel_main/gitignore
@@ -11,3 +11,6 @@ pom.xml
 .nrepl-port
 .cpcache/
 .rebel_readline_history
+resources/public/cljs-out/
+.clj-kondo/.cache
+{{#npm-bundle?}}node_modules/{{/npm-bundle?}}


### PR DESCRIPTION
Closes #14 

Instead of opening another issue, seemed prudent to just add `node_modules` to the template's .gitignore as well as I ran into that when I tried `+npm-bundle`.

I've also added `.clj-kondo/.cache` to both .gitignores. [clj-kondo](https://github.com/clj-kondo/clj-kondo) is one of the best tools that's come out for Clojure in the last couple years and this will allow for folks to seamlessly use it without accidentally committing their auto-generated cache files.